### PR TITLE
Added syntax definitions for Jinja templates which output: conf, python, shell, xml, yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,36 @@
 Provides syntax highlighting for jinja2 templates in atom.
 
 
-Adds a "jinja templates" syntax and an "HTML (Jinja templates)" syntax.
+Adds a "jinja templates" syntax and several combined syntax definintions, for jinja templates which output
+different types of file.
+
+## New Syntax Definintions
+
+In addition to the file extensions below, all syntax definintions also specify `.jinja2` & `.j2`.
+
+
+### "HTML (Jinja templates)" syntax
+
+Jinja templates for HTML files. Also matches `.html.j2`
+
+### "Generic Config (Jinja Templates)" syntax
+
+Jinja templates for Config files. Also matches `.conf.j2`.
+
+Requires the [language-generic-config](https://atom.io/packages/language-generic-config) package.
+
+### "Python (Jinja Templates)" syntax
+
+Jinja templates for Python files. Also matches `.py.j2`
+
+### "Shell Script (Jinja Templates)" syntax
+
+Jinja templates for Shell Script files. Also matches `.sh.j2`
+
+### "XML (Jinja Templates)" syntax
+
+Jinja templates for XML files. Also matches `.xml.j2`
+
+### "YAML (Jinja Templates)" syntax
+
+Jinja templates for YAML files. Also matches `.yml.j2` & `.yaml.j2`

--- a/grammars/conf (jinja templates).cson
+++ b/grammars/conf (jinja templates).cson
@@ -15,4 +15,4 @@
     'include': 'text.generic-config'
   }
 ]
-'scopeName': 'source.generic-config.jinja'
+'scopeName': 'text.generic-config.jinja'

--- a/grammars/conf (jinja templates).cson
+++ b/grammars/conf (jinja templates).cson
@@ -1,0 +1,18 @@
+'fileTypes': [
+  'conf.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
+# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
+'name': 'Generic Config (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'text.generic-config'
+  }
+]
+'scopeName': 'source.generic-config.jinja'

--- a/grammars/html (jinja templates).cson
+++ b/grammars/html (jinja templates).cson
@@ -1,4 +1,5 @@
 'fileTypes': [
+  'html.j2',
   'jinja2',
   'j2'
 ]

--- a/grammars/jinja templates.cson
+++ b/grammars/jinja templates.cson
@@ -96,7 +96,7 @@
         'match': '(?<=\\{\\%-|\\{\\%)\\s*\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*[,=])'
       }
       {
-        'match': '\\b(and|else|if|in|import|not|or|recursive|with(out)?\\s+context)\\b'
+        'match': '\\b(and|as|else|if|in|import|not|or|recursive|with(out)?\\s+context)\\b'
         'name': 'keyword.control.jinja'
       }
       {

--- a/grammars/jinja templates.cson
+++ b/grammars/jinja templates.cson
@@ -96,7 +96,7 @@
         'match': '(?<=\\{\\%-|\\{\\%)\\s*\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*[,=])'
       }
       {
-        'match': '\\b(and|as|else|if|in|import|not|or|recursive|with(out)?\\s+context)\\b'
+        'match': '\\b(and|else|if|in|import|not|or|recursive|with(out)?\\s+context)\\b'
         'name': 'keyword.control.jinja'
       }
       {

--- a/grammars/markdown (jinja templates).cson
+++ b/grammars/markdown (jinja templates).cson
@@ -1,0 +1,18 @@
+'fileTypes': [
+  'md.j2',
+  'markdown.j2',
+  'jinja',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+'name': 'Markdown (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.gfm'
+  }
+]
+'scopeName': 'source.gfm.jinja'

--- a/grammars/python (jinja templates).cson
+++ b/grammars/python (jinja templates).cson
@@ -1,0 +1,18 @@
+'fileTypes': [
+  'py.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
+# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
+'name': 'Python (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.python'
+  }
+]
+'scopeName': 'source.python.jinja'

--- a/grammars/shell (jinja templates).cson
+++ b/grammars/shell (jinja templates).cson
@@ -1,0 +1,18 @@
+'fileTypes': [
+  'sh.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
+# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
+'name': 'Shell Script (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.shell'
+  }
+]
+'scopeName': 'source.shell.jinja'

--- a/grammars/xml (jinja templates).cson
+++ b/grammars/xml (jinja templates).cson
@@ -1,0 +1,18 @@
+'fileTypes': [
+  'xml.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
+# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
+'name': 'XML (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'text.xml'
+  }
+]
+'scopeName': 'source.xml.jinja'

--- a/grammars/xml (jinja templates).cson
+++ b/grammars/xml (jinja templates).cson
@@ -15,4 +15,4 @@
     'include': 'text.xml'
   }
 ]
-'scopeName': 'source.xml.jinja'
+'scopeName': 'text.xml.jinja'

--- a/grammars/yaml (jinja templates).cson
+++ b/grammars/yaml (jinja templates).cson
@@ -1,0 +1,19 @@
+'fileTypes': [
+  'yml.j2',
+  'yaml.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
+# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
+'name': 'YAML (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.yaml'
+  }
+]
+'scopeName': 'source.yaml.jinja'

--- a/snippets/atom-jinja2.cson
+++ b/snippets/atom-jinja2.cson
@@ -1,4 +1,4 @@
-'.source.jinja, .text.html.jinja':
+'.source.jinja, .text.html.jinja, .text.generic-config.jinja, .source.python.jinja, .source.shell.jinja, .text.xml.jinja, .source.yaml.jinja':
   'Block':
     'prefix': 'block'
     'body': '{% block ${1:name} %}\n\t$2\n{% endblock %}'


### PR DESCRIPTION
This pull request adds new syntax definitions for several other type of files. These are a copy of the original html one, adapted to other file types:
- .conf.j2
- .py.j2
- .sh.j2
- .xml.j2
- .yml.j2

Jinja templates get used a lot with [Ansible](https://github.com/ansible/ansible), for templating all sorts of different files, so this expands the supported definitions to cover the ones I commonly use.
