### PR TITLE
Added comment toggle to jinja2

### DIFF
--- a/settings/atom-jinja2.cson
+++ b/settings/atom-jinja2.cson
@@ -1,0 +1,4 @@
+'.source.jinja':
+  'editor':
+    'commentStart': '{# '
+    'commentEnd': ' #}'


### PR DESCRIPTION
Changed the default format comments  `/* ... */` to jinja2 format `{# ... #}` when use Toggle Line comments `Ctrl+/`
