### PR TITLE
[Needs Some Work] Add json.j2 to supported file types

### DIFF
--- a/grammars/json (jinja templates).cson
+++ b/grammars/json (jinja templates).cson
@@ -4,15 +4,34 @@
   'j2'
 ]
 'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
-# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
-# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
 'name': 'JSON (Jinja Templates)'
 'patterns': [
-  {
-    'include': 'source.jinja'
-  }
-  {
-    'include': 'source.json'
-  }
+    {
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end'
+        'name': 'string.quoted'
+        'patterns':[
+            {
+                'include': 'source.jinja'
+            }
+        ]
+    }
+    {
+        'match': '[-]?[0-9]+[.]?[0-9]*'
+        'name': 'constant.numeric'
+    }
+    {
+        'match': 'true|false|none'
+        'name': 'constant'
+    }
+    {
+        'include': 'source.jinja'
+    }
 ]
 'scopeName': 'source.json.jinja'

--- a/grammars/json (jinja templates).cson
+++ b/grammars/json (jinja templates).cson
@@ -1,0 +1,18 @@
+'fileTypes': [
+  'json.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+# 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
+# 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
+'name': 'JSON (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.json'
+  }
+]
+'scopeName': 'source.json.jinja'


### PR DESCRIPTION
So, i tried joining `source.jinja` and `source.json`, and it works pretty well, **but**:

There is issue with first `{%  %}` being marked as invalid(and breaking rest of the code) when inside `{}` JSON-object, i don't know how to override this. Any help would be appreciated.

 `{%  %}` placed outside JSON-object works correctly.

