### PR TITLE
add sql support

### DIFF
--- a/grammars/sql (jinja templates).cson
+++ b/grammars/sql (jinja templates).cson
@@ -1,0 +1,17 @@
+'fileTypes': [
+  'sql.j2',
+  'jinja',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+'name': 'SQL (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.sql'
+  }
+]
+'scopeName': 'text.sql.jinja'

--- a/snippets/atom-jinja2.cson
+++ b/snippets/atom-jinja2.cson
@@ -1,4 +1,4 @@
-'.source.jinja, .text.html.jinja, .text.generic-config.jinja, .source.python.jinja, .source.shell.jinja, .text.xml.jinja, .source.yaml.jinja':
+'.source.jinja, .text.html.jinja, .text.generic-config.jinja, .source.python.jinja, .source.shell.jinja, .text.xml.jinja, .source.yaml.jinja, .text.sql.jinja':
   'Block':
     'prefix': 'block'
     'body': '{% block ${1:name} %}\n\t$2\n{% endblock %}'


### PR DESCRIPTION
For cases where Jinja2 is used for templating SQL queries. See https://github.com/hashedin/jinjasql