### PR TITLE
Add SQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Jinja templates for Python files. Also matches `.py.j2`
 
 Jinja templates for Shell Script files. Also matches `.sh.j2`
 
+### "SQL (Jinja Templates)" syntax
+
+Jinja templates for SQL files. Also matches `.sql.j2`
+
 ### "XML (Jinja Templates)" syntax
 
 Jinja templates for XML files. Also matches `.xml.j2`

--- a/grammars/sql (jinja templates).cson
+++ b/grammars/sql (jinja templates).cson
@@ -1,0 +1,16 @@
+'fileTypes': [
+  'sql.j2',
+  'jinja2',
+  'j2'
+]
+'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
+'name': 'SQL (Jinja Templates)'
+'patterns': [
+  {
+    'include': 'source.jinja'
+  }
+  {
+    'include': 'source.sql'
+  }
+]
+'scopeName': 'source.sql.jinja'

--- a/snippets/atom-jinja2.cson
+++ b/snippets/atom-jinja2.cson
@@ -1,4 +1,4 @@
-'.source.jinja, .text.html.jinja, .text.generic-config.jinja, .source.python.jinja, .source.shell.jinja, .text.xml.jinja, .source.yaml.jinja':
+'.source.jinja, .text.html.jinja, .text.generic-config.jinja, .source.python.jinja, .source.shell.jinja, .text.xml.jinja, .source.yaml.jinja, .source.sql.jinja':
   'Block':
     'prefix': 'block'
     'body': '{% block ${1:name} %}\n\t$2\n{% endblock %}'


### PR DESCRIPTION
I use Jinja in my SQL when using open source tool [dbt](https://www.getdbt.com/), so have been using a version of this package for my highlighting.

One thing that I'm stuck on is getting Jinja highlighting to work within round braces (`()`), for example, the Jinja in the common table expression does not get highlighted:
```sql
with order_payments as (
  select
  order_id
  {% for payment_method in payment_methods -%}
  , sum(case when payment_method = '{{payment_method}}' then amount else 0 end) as {{payment_method}}_amount
  {% endfor -%}
  from {{ ref('base_payments') }}
  group by 1
)
select
*
from order_payments
```
I suspect that [this](https://github.com/atom/language-sql/blob/master/grammars/sql.cson#L285) line is the culprit – any ideas on how to get around it?